### PR TITLE
Add differenceDirname optional argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ An optional second argument can be provided, which when provided can contain the
 * snapshotDirname: The name of the directory containing the snapshots to evaluate, relative to `parentURL`. Defaults to `"__snapshots__"`.
 * failOnUnmatchedSnapshots: Whether to raise an exception during cleanup (see below) if there are any unmatched snapshots in `snapshotDirname`. Defaults to `false` if node was invoked with the `--test-only` command-line option, `true` otherwise.
 * updateSnapshots: When `true` the snapshotter will skip the matching process and instead write the input to the corresponding snapshot file. Defaults to `true` if node was invoked with the `--test-update-snapshots` command-line option, `false` otherwise.
+* differenceDirname: The name of the directory where the diff images will be stored. Defaults to an operating system temporary folder. Use `import.meta.dirname` for directory name of current module.
 
 The return value is the snapshotter function which will be used to create snapshots and assert no differences in future runs:
 

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ import { PNG } from "pngjs";
  * @param {boolean} [options.failOnUnmatchedSnapshots]
  * @param {string} [options.snapshotDirname]
  * @param {boolean} [options.updateSnapshots]
+ * @param {string} [options.differenceDirname]
  * @return {Promise<PNGSnapshotter>}
  */
 export default async function createPNGSnapshotter(
@@ -28,6 +29,7 @@ export default async function createPNGSnapshotter(
 		failOnUnmatchedSnapshots = !process.execArgv.includes("--test-only"),
 		snapshotDirname = "__snapshots__",
 		updateSnapshots = process.execArgv.includes("--test-update-snapshots"),
+		differenceDirname = os.tmpdir(),
 	} = {},
 ) {
 	const snapshotsLocation = new URL(`${snapshotDirname}/`, parentURL);
@@ -64,7 +66,7 @@ export default async function createPNGSnapshotter(
 			);
 			if (width !== expected.width || height !== expected.height) {
 				const actualFilename = path.join(
-					os.tmpdir(),
+					differenceDirname,
 					`actual_${snapshotFilename}`,
 				);
 				await fs.writeFile(actualFilename, PNG.sync.write(actual));
@@ -79,7 +81,7 @@ export default async function createPNGSnapshotter(
 				PNG.bitblt(diff, comparison, 0, 0, width, height, width, 0);
 				PNG.bitblt(actual, comparison, 0, 0, width, height, width * 2, 0);
 				const comparisonFileName = path.join(
-					os.tmpdir(),
+					differenceDirname,
 					`expected-diff-actual_${snapshotFilename}`,
 				);
 				await fs.writeFile(comparisonFileName, PNG.sync.write(comparison));


### PR DESCRIPTION
Add option to change diff file directory.

This option helps developers open the difference files with tools of their choice and organise the files as they choose.